### PR TITLE
Fix # 28 login screen elements overlap removed in landscape mode

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -34,8 +34,11 @@
         android:textColor="@color/jetBlack"
         android:background="@color/white"
         android:paddingLeft="5dp"
-        app:layout_constraintStart_toEndOf="@id/textView2"
-        app:layout_constraintTop_toTopOf="@id/textView2"/>
+        app:layout_constraintBottom_toTopOf="@+id/password_text"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        android:layout_marginBottom="10dp"
+        />
 
     <EditText
         android:id="@+id/password_text"
@@ -47,9 +50,12 @@
         android:elevation="2dp"
         android:textColor="@color/jetBlack"
         android:background="@color/white"
-        android:paddingLeft="5dp"
-        app:layout_constraintStart_toEndOf="@id/textView3"
-        app:layout_constraintTop_toTopOf="@id/textView3" />
+        android:paddingLeft="10dp"
+        app:layout_constraintBottom_toTopOf="@+id/login_button"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        android:layout_marginBottom="5dp"
+        />
 
     <TextView
         android:id="@+id/textView2"
@@ -59,12 +65,11 @@
         android:textAppearance="@style/TextAppearance.AppCompat"
         android:elevation="2dp"
         android:textColor="@color/white"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintHorizontal_bias="0.1"
-        app:layout_constraintVertical_bias="0.3" />
+        app:layout_constraintRight_toLeftOf="@+id/username_text"
+        app:layout_constraintBottom_toTopOf="@+id/password_text"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="10dp"
+        />
 
     <TextView
         android:id="@+id/textView3"
@@ -74,12 +79,11 @@
         android:textAppearance="@style/TextAppearance.AppCompat"
         android:elevation="2dp"
         android:textColor="@color/white"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintHorizontal_bias="0.1"
-        app:layout_constraintVertical_bias="0.4" />
+        app:layout_constraintRight_toLeftOf="@+id/password_text"
+        app:layout_constraintBottom_toTopOf="@+id/login_button"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="10dp"
+        />
 
    <!-- <Button
         android:id="@+id/button5"


### PR DESCRIPTION
Fix #28 
![screenshot_20190305-182613](https://user-images.githubusercontent.com/32041242/53806986-6ed94600-3f74-11e9-9673-3d8bf6a7da1b.png)
