### PR TITLE
fix: Centered text and removed hardcoded string

### DIFF
--- a/app/src/main/java/memphis/myapplication/ViewFriendsActivity.java
+++ b/app/src/main/java/memphis/myapplication/ViewFriendsActivity.java
@@ -31,11 +31,11 @@ public class ViewFriendsActivity extends AppCompatActivity {
         // if we don't have any saved friends, we have nothing to display; tell user
         if(friendsList.isEmpty()) {
             TextView message = new TextView(this);
-            String s = "You currently haven't added any friends.";
-            message.setText(s);
+            message.setText(R.string.no_friends);
             message.setTextColor(white);
             message.setTextSize(24);
-            message.setGravity(Gravity.LEFT);
+            message.setGravity(Gravity.CENTER);
+            linearLayout.setGravity(Gravity.CENTER);
             linearLayout.addView(message);
         }
         else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="friends">Friends</string>
     <string name="files">Files</string>
     <string name="friends_title">Friends</string>
+    <string name="no_friends">You currently haven\'t added any friends.</string>
 
     <!--add friend activity-->
     <string name="display_qr">Display QR</string>


### PR DESCRIPTION
fix #64 
Hardcoded strings have been removed.
Text has been centered.
Changes:-
Before:-
![whatsapp image 2019-03-07 at 2 50 20 pm](https://user-images.githubusercontent.com/43093724/53945837-889b9a00-40e8-11e9-936a-b4704a1f56eb.jpeg)
After:-
![whatsapp image 2019-03-07 at 2 49 56 pm](https://user-images.githubusercontent.com/43093724/53945876-9d782d80-40e8-11e9-8776-bd7b875695e2.jpeg)

