### PR TITLE
fix: missing height in toolbar landscape

### DIFF
--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -9,7 +9,8 @@
     <include
         android:id="@+id/toolbar"
         layout="@layout/toolbar"
-        android:layout_width="729dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
Fix for #69 