### PR TITLE
fix: Added Necessary Margin

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -18,7 +18,7 @@
     <ImageView
         android:id="@+id/camera"
         android:layout_width="@dimen/margin_178dp"
-        android:layout_height="@dimen/margin_195dp"
+        android:layout_height="@dimen/margin_205dp"
         android:layout_marginStart="@dimen/margin_16dp"
         android:layout_marginTop="@dimen/margin_32dp"
         android:contentDescription="@string/camera"
@@ -30,7 +30,7 @@
     <ImageView
         android:id="@+id/files"
         android:layout_width="@dimen/margin_178dp"
-        android:layout_height="@dimen/margin_195dp"
+        android:layout_height="@dimen/margin_205dp"
         android:layout_marginTop="@dimen/margin_32dp"
         android:layout_marginEnd="@dimen/margin_16dp"
         android:contentDescription="@string/files"
@@ -42,7 +42,8 @@
     <ImageView
         android:id="@+id/friends"
         android:layout_width="@dimen/margin_178dp"
-        android:layout_height="@dimen/margin_195dp"
+        android:layout_height="@dimen/margin_205dp"
+        android:layout_marginBottom="@dimen/margin_8dp"
         android:layout_marginStart="@dimen/margin_16dp"
         android:layout_marginTop="@dimen/margin_32dp"
         android:contentDescription="@string/friends"
@@ -54,7 +55,8 @@
     <ImageView
         android:id="@+id/rcvdImages"
         android:layout_width="@dimen/margin_178dp"
-        android:layout_height="@dimen/margin_195dp"
+        android:layout_height="@dimen/margin_205dp"
+        android:layout_marginBottom="@dimen/margin_8dp"
         android:layout_marginTop="@dimen/margin_32dp"
         android:layout_marginEnd="@dimen/margin_16dp"
         android:contentDescription="@string/received_images"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -22,7 +22,7 @@
     <dimen name="margin_158dp">158dp</dimen>
     <dimen name="margin_32dp">32dp</dimen>
     <dimen name="margin_178dp">178dp</dimen>
-    <dimen name="margin_195dp">195dp</dimen>
+    <dimen name="margin_205dp">205dp</dimen>
     <dimen name="margin_5dp">5dp</dimen>
 
     <!--dimensions for textsize-->


### PR DESCRIPTION
fixes #113
The word "Friends" overlaps with the imageview.
Added proper margin.
Before:-
![Screenshot_20190306-055817](https://user-images.githubusercontent.com/43093724/54307401-9de55c80-45f1-11e9-80a7-5aba2bbe77f3.png)
After:-
![Screenshot_20190309-040109](https://user-images.githubusercontent.com/43093724/54307411-a473d400-45f1-11e9-8970-cb59846bc58d.png)
